### PR TITLE
Configurable bufferSize

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ const options = {
   channels: 1,        // 1 or 2, default 1
   bitsPerSample: 16,  // 8 or 16, default 16
   audioSource: 6,     // android only (see below)
+  bufferSize: 4096    // default is 2048
 };
 
 LiveAudioStream.init(options);

--- a/android/src/main/java/com/imxiqi/rnliveaudiostream/RNLiveAudioStreamModule.java
+++ b/android/src/main/java/com/imxiqi/rnliveaudiostream/RNLiveAudioStreamModule.java
@@ -13,6 +13,8 @@ import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 
+import java.lang.Math;
+
 public class RNLiveAudioStreamModule extends ReactContextBaseJavaModule {
 
     private final ReactApplicationContext reactContext;
@@ -67,6 +69,11 @@ public class RNLiveAudioStreamModule extends ReactContextBaseJavaModule {
         eventEmitter = reactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class);
 
         bufferSize = AudioRecord.getMinBufferSize(sampleRateInHz, channelConfig, audioFormat);
+
+		if (options.hasKey("bufferSize")) {
+            bufferSize = Math.max(bufferSize, options.getInt("bufferSize"));
+        }
+
         int recordingBufferSize = bufferSize * 3;
         recorder = new AudioRecord(audioSource, sampleRateInHz, channelConfig, audioFormat, recordingBufferSize);
     }

--- a/android/src/main/java/com/imxiqi/rnliveaudiostream/RNLiveAudioStreamModule.java
+++ b/android/src/main/java/com/imxiqi/rnliveaudiostream/RNLiveAudioStreamModule.java
@@ -70,7 +70,7 @@ public class RNLiveAudioStreamModule extends ReactContextBaseJavaModule {
 
         bufferSize = AudioRecord.getMinBufferSize(sampleRateInHz, channelConfig, audioFormat);
 
-		if (options.hasKey("bufferSize")) {
+        if (options.hasKey("bufferSize")) {
             bufferSize = Math.max(bufferSize, options.getInt("bufferSize"));
         }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,7 +21,7 @@ declare module "react-native-live-audio-stream" {
      */
     audioSource?: number
     wavFile: string
-	bufferSize?: number
+    bufferSize?: number
   }
 
   const AudioRecord: IAudioRecord

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,6 +21,7 @@ declare module "react-native-live-audio-stream" {
      */
     audioSource?: number
     wavFile: string
+	bufferSize?: number
   }
 
   const AudioRecord: IAudioRecord

--- a/ios/RNLiveAudioStream.m
+++ b/ios/RNLiveAudioStream.m
@@ -15,7 +15,7 @@ RCT_EXPORT_METHOD(init:(NSDictionary *) options) {
     _recordState.mDataFormat.mReserved          = 0;
     _recordState.mDataFormat.mFormatID          = kAudioFormatLinearPCM;
     _recordState.mDataFormat.mFormatFlags       = _recordState.mDataFormat.mBitsPerChannel == 8 ? kLinearPCMFormatFlagIsPacked : (kLinearPCMFormatFlagIsSignedInteger | kLinearPCMFormatFlagIsPacked);
-    _recordState.bufferByteSize 				= options[@"bufferSize"] == nil ? 2048 : [options[@"bufferSize"] unsignedIntValue];
+    _recordState.bufferByteSize                 = options[@"bufferSize"] == nil ? 2048 : [options[@"bufferSize"] unsignedIntValue];
     _recordState.mSelf = self;
 }
 

--- a/ios/RNLiveAudioStream.m
+++ b/ios/RNLiveAudioStream.m
@@ -15,7 +15,7 @@ RCT_EXPORT_METHOD(init:(NSDictionary *) options) {
     _recordState.mDataFormat.mReserved          = 0;
     _recordState.mDataFormat.mFormatID          = kAudioFormatLinearPCM;
     _recordState.mDataFormat.mFormatFlags       = _recordState.mDataFormat.mBitsPerChannel == 8 ? kLinearPCMFormatFlagIsPacked : (kLinearPCMFormatFlagIsSignedInteger | kLinearPCMFormatFlagIsPacked);
-    _recordState.bufferByteSize = 2048;
+    _recordState.bufferByteSize 				= options[@"bufferSize"] == nil ? 2048 : [options[@"bufferSize"] unsignedIntValue];
     _recordState.mSelf = self;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-live-audio-stream",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Get live audio stream data for React Native",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
## What
Makes the bufferSize configurable as an option to pass from JS to native code.

## Why
It is helpful in some scenarios, e.g. further processing of live audio, to adjust the buffer size to ones own desire

## Breaking changes?
Since the new "bufferSize" option is optional and defaults to the previous values the change is non-breaking