### PR TITLE
Fix recording error

### DIFF
--- a/ios/RNLiveAudioStream.m
+++ b/ios/RNLiveAudioStream.m
@@ -47,7 +47,7 @@ RCT_EXPORT_METHOD(start) {
 
     OSStatus status = AudioQueueNewInput(&_recordState.mDataFormat, HandleInputBuffer, &_recordState, NULL, NULL, 0, &_recordState.mQueue);
     if (status != 0) {
-        RCTLog(@"[RNLiveAudioStream] Record Failed. Cannot initialize AudioQueueNewInput. status: %i", status);
+        RCTLog(@"[RNLiveAudioStream] Record Failed. Cannot initialize AudioQueueNewInput. status: %i", (int) status);
         return;
     }
 

--- a/ios/RNLiveAudioStream.m
+++ b/ios/RNLiveAudioStream.m
@@ -47,7 +47,7 @@ RCT_EXPORT_METHOD(start) {
 
     OSStatus status = AudioQueueNewInput(&_recordState.mDataFormat, HandleInputBuffer, &_recordState, NULL, NULL, 0, &_recordState.mQueue);
     if (status != 0) {
-        RCTLog(@"[RNLiveAudioStream] Record Failed. Cannot initialize AudioQueueNewInput. status: %d", status);
+        RCTLog(@"[RNLiveAudioStream] Record Failed. Cannot initialize AudioQueueNewInput. status: %i", status);
         return;
     }
 

--- a/ios/RNLiveAudioStream.m
+++ b/ios/RNLiveAudioStream.m
@@ -59,7 +59,7 @@ RCT_EXPORT_METHOD(start) {
 }
 
 RCT_EXPORT_METHOD(stop) {
-    RCTLogInfo(@"[RNLiveAudioStream] stopRecording");
+    RCTLogInfo(@"[RNLiveAudioStream] stop");
     if (_recordState.mIsRunning) {
         _recordState.mIsRunning = false;
         AudioQueueStop(_recordState.mQueue, true);


### PR DESCRIPTION
Fix recording error (cannot set AVAudioSession mode that is not supported by current AVAudioSession category). Added error capturing and logging for failed audio session initialisation. Stop recording if audio queue initialisation failed. Release audio queue buffer on stop recording.