### PR TITLE
Remove `wavFile` from TypeScript type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -20,7 +20,6 @@ declare module "react-native-live-audio-stream" {
      * - `6`
      */
     audioSource?: number
-    wavFile: string
     bufferSize?: number
   }
 


### PR DESCRIPTION
This option is not used in this library, however as the TypeScript types
(defined in `index.d.ts`) were copied from `react-native-audio-record`,
it's still declared as a mandatory field in the types.

This removes it from the type definition so that it's not required in
order to use this library in a TypeScript-based environment.